### PR TITLE
accessEgressType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 	<description>MATSim Open Berlin scenario project</description>
 
 	<properties>
-		<!-- <matsim.version>13.0-SNAPSHOT</matsim.version> -->
-		<matsim.version>13.0-2020w26-SNAPSHOT</matsim.version>
+<!--		 <matsim.version>13.0-SNAPSHOT</matsim.version>-->
+		<matsim.version>13.0-2020w28-SNAPSHOT</matsim.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/org/matsim/run/RunBerlinScenario.java
+++ b/src/main/java/org/matsim/run/RunBerlinScenario.java
@@ -37,7 +37,7 @@ import org.matsim.contrib.drt.routing.DrtRouteFactory;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup.AccessEgressWalkType;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ActivityParams;
 import org.matsim.core.config.groups.QSimConfigGroup.TrafficDynamics;
 import org.matsim.core.config.groups.VspExperimentalConfigGroup;
@@ -195,7 +195,7 @@ public final class RunBerlinScenario {
 				
 		// vsp defaults
 		config.vspExperimental().setVspDefaultsCheckingLevel( VspExperimentalConfigGroup.VspDefaultsCheckingLevel.info );
-		config.plansCalcRoute().setInsertingAccessEgressWalk( AccessEgressWalkType.walkToLink );
+		config.plansCalcRoute().setAccessEgressType(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLink);
 		config.qsim().setUsingTravelTimeCheckInTeleportation( true );
 		config.qsim().setTrafficDynamics( TrafficDynamics.kinematicWaves );
 				

--- a/src/main/java/org/matsim/run/ptdisturbances/RunPtDisturbancesBerlin.java
+++ b/src/main/java/org/matsim/run/ptdisturbances/RunPtDisturbancesBerlin.java
@@ -42,8 +42,8 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup.AccessEgressWalkType;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ActivityParams;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup.TrafficDynamics;
 import org.matsim.core.config.groups.VspExperimentalConfigGroup;
 import org.matsim.core.controler.AbstractModule;
@@ -330,7 +330,7 @@ public final class RunPtDisturbancesBerlin {
 				
 		// vsp defaults
 		config.vspExperimental().setVspDefaultsCheckingLevel( VspExperimentalConfigGroup.VspDefaultsCheckingLevel.info );
-		config.plansCalcRoute().setInsertingAccessEgressWalk( AccessEgressWalkType.walkToLink );
+		config.plansCalcRoute().setAccessEgressType(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLink);
 		config.qsim().setUsingTravelTimeCheckInTeleportation( true );
 		config.qsim().setTrafficDynamics( TrafficDynamics.kinematicWaves );
 				


### PR DESCRIPTION
Update accessEgressType settings in plansCalcRoute to recent changes in matsim-libs.

The enum in plansCalcRouteConfigGroup has changes this week. Hopefully, the next weekly release of matsim-libs will get built so we can update and merge this branch into 5.5.x - after updating the dependency on matsim-libs to the new weekly release (week 29), of course.... 