### PR TITLE
change matsim version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ env:
     # - TEST=RunBerlinScenarioIT#test10pctUntilIteration1 # does not fit into travis.  kai, aug'18
     # - TEST=RunBerlinScenarioIT#test1pctManyIterations # does probably not fit into travis (not tested).  kai, aug'18
     - TEST=RunOfflineAirPollutionAnalysisTest
+    - TEST=RunOfflineNoiseAnalysisTest
 script:
   - mvn -Dtest=${TEST} test --batch-mode -Dmatsim.preferLocalDtds=true -Dmaven.javadoc.skip -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ env:
     - TEST=RunDrtOpenBerlinScenarioWithDrtSpeedUpTest
     # - TEST=RunBerlinScenarioIT#test10pctUntilIteration1 # does not fit into travis.  kai, aug'18
     # - TEST=RunBerlinScenarioIT#test1pctManyIterations # does probably not fit into travis (not tested).  kai, aug'18
+    - TEST=RunOfflineAirPollutionAnalysisTest
 script:
   - mvn -Dtest=${TEST} test --batch-mode -Dmatsim.preferLocalDtds=true -Dmaven.javadoc.skip -e

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 <!--				<matsim.version>13.0-SNAPSHOT</matsim.version>-->
-		<matsim.version>13.0-2021w03-SNAPSHOT</matsim.version>
+		<matsim.version>13.0-2020w51-SNAPSHOT</matsim.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.matsim-scenarios</groupId>
 	<artifactId>matsim-berlin</artifactId>
-	<version>5.5.1</version>
+	<version>5.5.2</version>
 
 	<name>MATSim Open Berlin scenario project</name>
 	<description>MATSim Open Berlin scenario project</description>
 
 	<properties>
-		<!--		<matsim.version>13.0-SNAPSHOT</matsim.version>-->
-		<matsim.version>13.0-2021w02-SNAPSHOT</matsim.version>
+<!--				<matsim.version>13.0-SNAPSHOT</matsim.version>-->
+		<matsim.version>13.0-2021w03-SNAPSHOT</matsim.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>com.github.matsim-vsp</groupId>
 			<artifactId>opt-drt</artifactId>
-			<version>0a4ad0fe73</version>
+			<version>e955606ea4</version>
 		</dependency>
 		
 		<dependency>

--- a/src/main/java/org/matsim/analysis/RunOfflineAirPollutionAnalysis.java
+++ b/src/main/java/org/matsim/analysis/RunOfflineAirPollutionAnalysis.java
@@ -27,7 +27,6 @@ import org.matsim.contrib.emissions.HbefaVehicleCategory;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.DetailedVsAverageLookupBehavior;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.HbefaRoadTypeSource;
-import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.HbefaVehicleDescriptionSource;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.NonScenarioVehicles;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;

--- a/src/main/java/org/matsim/analysis/RunOfflineAirPollutionAnalysis.java
+++ b/src/main/java/org/matsim/analysis/RunOfflineAirPollutionAnalysis.java
@@ -48,29 +48,54 @@ import org.matsim.vehicles.VehicleUtils;
 
 public class RunOfflineAirPollutionAnalysis {
 	
-	final static String runDirectory = "public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-10pct/output-berlin-v5.4-10pct/";	
-	final static String runId = "berlin-v5.4-10pct";
+	private final String runDirectory;
+	private final String runId;
+	private final String hbefaWarmFile;
+	private final String hbefaColdFile;
+	private final String analysisOutputDirectory;
 
-	final static String hbefaFileCold = "shared-svn/projects/matsim-germany/hbefa/hbefa-files/v3.2/EFA_ColdStart_vehcat_2005average.txt";
-	final static String hbefaFileWarm = "shared-svn/projects/matsim-germany/hbefa/hbefa-files/v3.2/EFA_HOT_vehcat_2005average.txt";
-	
 	public static void main(String[] args) {
-		
-		String rootDirectory = null;
-		
+				
 		if (args.length == 1) {
-			rootDirectory = args[0];
+			String rootDirectory = args[0];
+			if (!rootDirectory.endsWith("/")) rootDirectory = rootDirectory + "/";
+			
+			final String runDirectory = "public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-10pct/output-berlin-v5.4-10pct/";	
+			final String runId = "berlin-v5.4-10pct";
+
+			final String hbefaFileCold = "shared-svn/projects/matsim-germany/hbefa/hbefa-files/v3.2/EFA_ColdStart_vehcat_2005average.txt";
+			final String hbefaFileWarm = "shared-svn/projects/matsim-germany/hbefa/hbefa-files/v3.2/EFA_HOT_vehcat_2005average.txt";
+			
+			RunOfflineAirPollutionAnalysis analysis = new RunOfflineAirPollutionAnalysis(
+					rootDirectory + runDirectory,
+					runId,
+					rootDirectory + hbefaFileWarm,
+					rootDirectory + hbefaFileCold,
+					rootDirectory + runDirectory);
+			analysis.run();
+			
 		} else {
 			throw new RuntimeException("Please set the root directory. Aborting...");
 		}
+	}
+	
+	public RunOfflineAirPollutionAnalysis(String runDirectory, String runId, String hbefaFileWarm, String hbefaFileCold, String analysisOutputDirectory) {
+		this.runDirectory = runDirectory;
+		this.runId = runId;
+		this.hbefaWarmFile = hbefaFileWarm;
+		this.hbefaColdFile = hbefaFileCold;
 		
-		if (!rootDirectory.endsWith("/")) rootDirectory = rootDirectory + "/";
-		
+		if (!analysisOutputDirectory.endsWith("/")) analysisOutputDirectory = analysisOutputDirectory + "/";
+		this.analysisOutputDirectory = analysisOutputDirectory;
+	}
+
+	void run() {
+
 		Config config = ConfigUtils.createConfig();
-		config.vehicles().setVehiclesFile(rootDirectory + runDirectory + runId + ".output_vehicles.xml.gz");
-		config.network().setInputFile(rootDirectory + runDirectory + runId + ".output_network.xml.gz");
-		config.transit().setTransitScheduleFile(rootDirectory + runDirectory + runId + ".output_transitSchedule.xml.gz");
-		config.transit().setVehiclesFile(rootDirectory + runDirectory + runId + ".output_transitVehicles.xml.gz");
+		config.vehicles().setVehiclesFile(runDirectory + runId + ".output_vehicles.xml.gz");
+		config.network().setInputFile(runDirectory + runId + ".output_network.xml.gz");
+		config.transit().setTransitScheduleFile(runDirectory + runId + ".output_transitSchedule.xml.gz");
+		config.transit().setVehiclesFile(runDirectory + runId + ".output_transitVehicles.xml.gz");
 		config.global().setCoordinateSystem("GK4");
 		config.plans().setInputFile(null);
 		config.parallelEventHandling().setNumberOfThreads(null);
@@ -79,16 +104,15 @@ public class RunOfflineAirPollutionAnalysis {
 		
 		EmissionsConfigGroup eConfig = ConfigUtils.addOrGetModule(config, EmissionsConfigGroup.class);
 		eConfig.setDetailedVsAverageLookupBehavior(DetailedVsAverageLookupBehavior.directlyTryAverageTable);
-		eConfig.setAverageColdEmissionFactorsFile(rootDirectory + hbefaFileCold);
-		eConfig.setAverageWarmEmissionFactorsFile(rootDirectory + hbefaFileWarm);
+		eConfig.setAverageColdEmissionFactorsFile(this.hbefaColdFile);
+		eConfig.setAverageWarmEmissionFactorsFile(this.hbefaWarmFile);
 		eConfig.setHbefaRoadTypeSource(HbefaRoadTypeSource.fromLinkAttributes);
 		eConfig.setNonScenarioVehicles(NonScenarioVehicles.ignore);
 		
-		final String emissionEventOutputFile = rootDirectory + runDirectory + runId + ".emission.events.offline.xml.gz";
-		final String eventsFile = rootDirectory + runDirectory + runId + ".output_events.xml.gz";
+		final String emissionEventOutputFile = analysisOutputDirectory + runId + ".emission.events.offline.xml.gz";
+		final String eventsFile = runDirectory + runId + ".output_events.xml.gz";
 		
 		Scenario scenario = ScenarioUtils.loadScenario(config);
-		
 		// network
 		for (Link link : scenario.getNetwork().getLinks().values()) {
 
@@ -194,7 +218,7 @@ public class RunOfflineAirPollutionAnalysis {
         matsimEventsReader.readFile(eventsFile);
         eventsManager.finishProcessing();
 
-        emissionEventWriter.closeFile();
+        emissionEventWriter.closeFile();	
 	}
 
 }

--- a/src/main/java/org/matsim/analysis/RunOfflineNoiseAnalysis.java
+++ b/src/main/java/org/matsim/analysis/RunOfflineNoiseAnalysis.java
@@ -36,26 +36,42 @@ import org.matsim.core.scenario.ScenarioUtils;
  */
 public class RunOfflineNoiseAnalysis {
 	private static final Logger log = Logger.getLogger(RunOfflineNoiseAnalysis.class);
+	
+	private final String runDirectory;
+	private final String runId;
+	private final String analysisOutputDirectory;
+	
+//	private final String tunnelLinkIdFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-10pct/input/berlin-v5.1.tunnel-linkIDs.csv";
+	private final String tunnelLinkIdFile = null;
 
-	private final static String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-1pct/output-berlin-v5.4-1pct/";
-	private final static String runId = "berlin-v5.4-1pct";
+//	private final String noiseBarriersFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-buildings/osm-buildings-dissolved.geojson";
+	private final String noiseBarriersFile = null;
+
+	public RunOfflineNoiseAnalysis(String runDirectory, String runId, String analysisOutputDirectory) {
+		this.runDirectory = runDirectory;
+		this.runId = runId;
+		
+		if (!analysisOutputDirectory.endsWith("/")) analysisOutputDirectory = analysisOutputDirectory + "/";
+		this.analysisOutputDirectory = analysisOutputDirectory;
+	}
 
 	public static void main(String[] args) {
+		
+		final String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-1pct/output-berlin-v5.4-1pct/";
+		final String runId = "berlin-v5.4-1pct";
+		
+		RunOfflineNoiseAnalysis analysis = new RunOfflineNoiseAnalysis(runDirectory, runId, "./scenario/");
+		analysis.run();
+	}
 
-		String outputDirectory = "./scenarios/";
-
-		String tunnelLinkIdFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-10pct/input/berlin-v5.10.tunnel-linkIDs.csv";
+	void run() {
 		double receiverPointGap = 100.;
 		double timeBinSize = 3600.;
 		
 		Config config = ConfigUtils.createConfig(new NoiseConfigGroup());
-		config.global().setCoordinateSystem("EPSG:31468");
-		config.network().setInputCRS("EPSG:31468");
-//		config.network().setInputFile(runDirectory + runId + ".output_network.xml.gz");
-		config.network().setInputFile("https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-v5.5-network.xml.gz");
-//		config.plans().setInputFile(runDirectory + runId + ".output_plans.xml.gz");
-		config.plans().setInputFile("https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-1pct/input/berlin-v5.5-1pct.plans.xml.gz");
-		config.plans().setInputCRS("EPSG:31468");
+		config.global().setCoordinateSystem("GK4");
+		config.network().setInputFile(runDirectory + runId + ".output_network.xml.gz");
+		config.plans().setInputFile(runDirectory + runId + ".output_plans.xml.gz");
 		config.controler().setOutputDirectory(runDirectory);
 		config.controler().setRunId(runId);
 						
@@ -96,16 +112,15 @@ public class RunOfflineNoiseAnalysis {
 		noiseParameters.setTimeBinSizeNoiseComputation(timeBinSize);
 
 		noiseParameters.setConsiderNoiseBarriers(false);
-		noiseParameters.setNoiseBarriersFilePath("/Users/ihab/Documents/workspace/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-buildings/osm-buildings-dissolved.geojson");
-//		noiseParameters.setNoiseBarriersFilePath("https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-buildings/osm-buildings-dissolved.geojson");
+		noiseParameters.setNoiseBarriersFilePath(noiseBarriersFile);
 		noiseParameters.setNoiseBarriersSourceCRS("EPSG:31468");
 		
 		Scenario scenario = ScenarioUtils.loadScenario(config);
-		NoiseOfflineCalculation noiseCalculation = new NoiseOfflineCalculation(scenario, outputDirectory);
+		NoiseOfflineCalculation noiseCalculation = new NoiseOfflineCalculation(scenario, analysisOutputDirectory);
 		noiseCalculation.run();	
 		
 		// some processing of the output data
-		String outputFilePath = outputDirectory + "noise-analysis/";
+		String outputFilePath = analysisOutputDirectory + "noise-analysis/";
 		ProcessNoiseImmissions process = new ProcessNoiseImmissions(outputFilePath + "immissions/", outputFilePath + "receiverPoints/receiverPoints.csv", noiseParameters.getReceiverPointGap());
 		process.run();
 				

--- a/src/test/java/org/matsim/analysis/RunOfflineAirPollutionAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/RunOfflineAirPollutionAnalysisTest.java
@@ -1,0 +1,47 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.analysis;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.testcases.MatsimTestUtils;
+
+public class RunOfflineAirPollutionAnalysisTest{
+
+	@Rule public MatsimTestUtils utils = new MatsimTestUtils() ;
+
+	// to run this test an environment variable needs to be set in your IDE and on the server...
+	@Test
+	public final void test1() {
+		try {
+			String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-1pct/output-berlin-v5.4-1pct/";
+			String runId = "berlin-v5.4-1pct";
+			String hbefaFileWarm = "https://svn.vsp.tu-berlin.de/repos/public-svn/3507bb3997e5657ab9da76dbedbb13c9b5991d3e/0e73947443d68f95202b71a156b337f7f71604ae/7eff8f308633df1b8ac4d06d05180dd0c5fdf577.enc";
+			String hbefaFileCold = "https://svn.vsp.tu-berlin.de/repos/public-svn/3507bb3997e5657ab9da76dbedbb13c9b5991d3e/0e73947443d68f95202b71a156b337f7f71604ae/22823adc0ee6a0e231f35ae897f7b224a86f3a7a.enc";
+			
+			RunOfflineAirPollutionAnalysis analysis = new RunOfflineAirPollutionAnalysis(runDirectory, runId, hbefaFileWarm, hbefaFileCold, utils.getOutputDirectory());
+			analysis.run();
+			
+		} catch ( Exception ee ) {
+			throw new RuntimeException(ee) ;
+		}
+	}
+
+}

--- a/src/test/java/org/matsim/analysis/RunOfflineAirPollutionAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/RunOfflineAirPollutionAnalysisTest.java
@@ -31,8 +31,8 @@ public class RunOfflineAirPollutionAnalysisTest{
 	@Test
 	public final void test1() {
 		try {
-			String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-1pct/output-berlin-v5.4-1pct/";
-			String runId = "berlin-v5.4-1pct";
+			String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-0.1pct/output-berlin-v5.4-0.1pct/";
+			String runId = "berlin-v5.4-0.1pct";
 			String hbefaFileWarm = "https://svn.vsp.tu-berlin.de/repos/public-svn/3507bb3997e5657ab9da76dbedbb13c9b5991d3e/0e73947443d68f95202b71a156b337f7f71604ae/7eff8f308633df1b8ac4d06d05180dd0c5fdf577.enc";
 			String hbefaFileCold = "https://svn.vsp.tu-berlin.de/repos/public-svn/3507bb3997e5657ab9da76dbedbb13c9b5991d3e/0e73947443d68f95202b71a156b337f7f71604ae/22823adc0ee6a0e231f35ae897f7b224a86f3a7a.enc";
 			

--- a/src/test/java/org/matsim/analysis/RunOfflineNoiseAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/RunOfflineNoiseAnalysisTest.java
@@ -1,0 +1,45 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.analysis;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.testcases.MatsimTestUtils;
+
+public class RunOfflineNoiseAnalysisTest{
+
+	@Rule public MatsimTestUtils utils = new MatsimTestUtils() ;
+
+	// to run this test an environment variable needs to be set in your IDE and on the server...
+	@Test
+	public final void test1() {
+		try {
+			String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-1pct/output-berlin-v5.4-1pct/";
+			String runId = "berlin-v5.4-1pct";
+			
+			RunOfflineNoiseAnalysis analysis = new RunOfflineNoiseAnalysis(runDirectory, runId, utils.getOutputDirectory());
+			analysis.run();
+			
+		} catch ( Exception ee ) {
+			throw new RuntimeException(ee) ;
+		}
+	}
+
+}

--- a/src/test/java/org/matsim/analysis/RunOfflineNoiseAnalysisTest.java
+++ b/src/test/java/org/matsim/analysis/RunOfflineNoiseAnalysisTest.java
@@ -31,8 +31,8 @@ public class RunOfflineNoiseAnalysisTest{
 	@Test
 	public final void test1() {
 		try {
-			String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-1pct/output-berlin-v5.4-1pct/";
-			String runId = "berlin-v5.4-1pct";
+			String runDirectory = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.4-0.1pct/output-berlin-v5.4-0.1pct/";
+			String runId = "berlin-v5.4-0.1pct";
 			
 			RunOfflineNoiseAnalysis analysis = new RunOfflineNoiseAnalysis(runDirectory, runId, utils.getOutputDirectory());
 			analysis.run();


### PR DESCRIPTION
This patch updates the matsim version. Before that matsim version, different dependencies (contribs) could and would point to different matsim versions. As a result, no one could say which pieces of code would be executed or in other words, plugged together.
Please see https://github.com/matsim-org/matsim-libs/issues/1343.