### PR TITLE
The Emission config has central infrastructure for HBEFA Road tags.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<!--<matsim.version>13.0</matsim.version>-->
 
 		<!-- PR-labelled release -->
-		<matsim.version>14.0-PR1884</matsim.version>
+		<matsim.version>14.0-PR1859</matsim.version>
 
 		<!-- snapshot == not recommended: rather use PR-labelled release!-->
 		<!--<matsim.version>14.0-SNAPSHOT</matsim.version>-->

--- a/src/main/java/org/matsim/analysis/emissions/RunOfflineAirPollutionAnalysisByEngineInformationWithDrt.java
+++ b/src/main/java/org/matsim/analysis/emissions/RunOfflineAirPollutionAnalysisByEngineInformationWithDrt.java
@@ -35,6 +35,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.emissions.EmissionModule;
 import org.matsim.contrib.emissions.HbefaVehicleCategory;
 import org.matsim.contrib.emissions.Pollutant;
+import org.matsim.contrib.emissions.VspHbefaRoadTypeMapping;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.DetailedVsAverageLookupBehavior;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.HbefaRoadTypeSource;
@@ -134,7 +135,6 @@ public class RunOfflineAirPollutionAnalysisByEngineInformationWithDrt {
 		eConfig.setDetailedVsAverageLookupBehavior(DetailedVsAverageLookupBehavior.tryDetailedThenTechnologyAverageElseAbort);
 		eConfig.setDetailedColdEmissionFactorsFile(hbefaColdFile);
 		eConfig.setDetailedWarmEmissionFactorsFile(hbefaWarmFile);
-		eConfig.setHbefaRoadTypeSource(HbefaRoadTypeSource.fromLinkAttributes);
 		eConfig.setNonScenarioVehicles(NonScenarioVehicles.ignore);
 		eConfig.setWritingEmissionsEvents(true);
 		
@@ -151,54 +151,7 @@ public class RunOfflineAirPollutionAnalysisByEngineInformationWithDrt {
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		
 		// network
-		for (Link link : scenario.getNetwork().getLinks().values()) {
-
-			double freespeed = Double.NaN;
-
-			if (link.getFreespeed() <= 13.888889) {
-				freespeed = link.getFreespeed() * 2;
-				// for non motorway roads, the free speed level was reduced
-			} else {
-				freespeed = link.getFreespeed();
-				// for motorways, the original speed levels seems ok.
-			}
-			
-			if(freespeed <= 8.333333333){ //30kmh
-				link.getAttributes().putAttribute("hbefa_road_type", "URB/Access/30");
-			} else if(freespeed <= 11.111111111){ //40kmh
-				link.getAttributes().putAttribute("hbefa_road_type", "URB/Access/40");
-			} else if(freespeed <= 13.888888889){ //50kmh
-				double lanes = link.getNumberOfLanes();
-				if(lanes <= 1.0){
-					link.getAttributes().putAttribute("hbefa_road_type", "URB/Local/50");
-				} else if(lanes <= 2.0){
-					link.getAttributes().putAttribute("hbefa_road_type", "URB/Distr/50");
-				} else if(lanes > 2.0){
-					link.getAttributes().putAttribute("hbefa_road_type", "URB/Trunk-City/50");
-				} else{
-					throw new RuntimeException("NoOfLanes not properly defined");
-				}
-			} else if(freespeed <= 16.666666667){ //60kmh
-				double lanes = link.getNumberOfLanes();
-				if(lanes <= 1.0){
-					link.getAttributes().putAttribute("hbefa_road_type", "URB/Local/60");
-				} else if(lanes <= 2.0){
-					link.getAttributes().putAttribute("hbefa_road_type", "URB/Trunk-City/60");
-				} else if(lanes > 2.0){
-					link.getAttributes().putAttribute("hbefa_road_type", "URB/MW-City/60");
-				} else{
-					throw new RuntimeException("NoOfLanes not properly defined");
-				}
-			} else if(freespeed <= 19.444444444){ //70kmh
-				link.getAttributes().putAttribute("hbefa_road_type", "URB/MW-City/70");
-			} else if(freespeed <= 22.222222222){ //80kmh
-				link.getAttributes().putAttribute("hbefa_road_type", "URB/MW-Nat./80");
-			} else if(freespeed > 22.222222222){ //faster
-				link.getAttributes().putAttribute("hbefa_road_type", "RUR/MW/>130");
-			} else{
-				throw new RuntimeException("Link not considered...");
-			}			
-		}
+		new VspHbefaRoadTypeMapping().addHbefaMappings(scenario.getNetwork());
 				
 		// car vehicles
 		


### PR DESCRIPTION
* Point to matsim-PR1859
* Replace Assignment of HBEFA-Road-Types in Offline Air Pollution calculation with VspHbefaRoadTypeMapping - This has the exact same behaviour as before bat is available at a central place now

Having this here, so that people can have a look. I this the correct Branch to merge into? Whoever feels responsible for this repository maybe @vsp-gleich or @tschlenther could confirm maybe.