### PR TITLE
fix: Repair Jitpack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+jdk:
+  - openjdk17
+

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,6 @@
 jdk:
   - openjdk17
-
+before_install:
+  - sdk install java 17.0.3-tem
+  - sdk use java 17.0.3-tem
+  - sdk install maven


### PR DESCRIPTION
I noticed that Jitpack refuses to build `matsim-berlin` with more recent versions of MATSim because it uses JDK 11 by default, it seems. This PR adds `jitpack.yml` which specifies the correct configuration for Jitpack (especially requiring the use of JDK17).