### PR TITLE
drt for berlin v6.x

### DIFF
--- a/input/v6.1/berlin-v6.1.drt-config.xml
+++ b/input/v6.1/berlin-v6.1.drt-config.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+
+	<module name="berlinExperimental" >
+		<param name="tagDrtLinksBufferAroundServiceAreaShp" value="5000.0" />
+	</module>
+
+	<module name="multiModeDrt">
+		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
+			<!-- If true, the startLink is changed to last link in the current schedule, so the taxi starts the next day at the link where it stopped operating the day before. False by default. -->
+			<param name="changeStartLinkToLastLinkInSchedule" value="true" />
+			<!-- allows to configure a service area per drt mode.Used with serviceArea Operational Scheme -->
+			<param name="drtServiceAreaShapeFile" value="https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v6.1/input/shp/Berlin_25832.shp" />
+			<!-- Idle vehicles return to the nearest of all start links. See: DvrpVehicle.getStartLink() -->
+			<param name="idleVehiclesReturnToDepots" value="false" />
+			<!-- Defines the slope of the maxTravelTime estimation function (optimisation constraint), i.e. maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. Alpha should not be smaller than 1. -->
+			<param name="maxTravelTimeAlpha" value="1.7" />
+			<!-- Defines the shift of the maxTravelTime estimation function (optimisation constraint), i.e. maxTravelTimeAlpha * estimated_drt_travel_time + maxTravelTimeBeta. Beta should not be smaller than 0. -->
+			<param name="maxTravelTimeBeta" value="120.0" />
+			<!-- Max wait time for the bus to come (optimisation constraint). -->
+			<param name="maxWaitTime" value="300.0" />
+			<!-- Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt. If no stop can be found within this maximum distance will return a direct walk of type drtMode_walk. -->
+			<param name="maxWalkDistance" value="2000.0" />
+			<!-- Mode which will be handled by PassengerEngine and VrpOptimizer (passengers'/customers' perspective) -->
+			<param name="mode" value="drt" />
+			<!-- Number of threads used for parallel evaluation of request insertion into existing schedules. Scales well up to 4, due to path data provision, the most computationally intensive part, using up to 4 threads. Default value is 'min(4, no. of cores available to JVM)' -->
+			<param name="numberOfThreads" value="8" />
+			<!-- Operational Scheme, either of door2door, stopbased or serviceAreaBased. door2door by default -->
+			<param name="operationalScheme" value="serviceAreaBased" />
+			<!-- If true, the max travel and wait times of a submitted request are considered hard constraints (the request gets rejected if one of the constraints is violated). If false, the max travel and wait times are considered soft constraints (insertion of a request that violates one of the constraints is allowed, but its cost is increased by additional penalty to make it relatively less attractive). Penalisation of insertions can be customised by injecting a customised InsertionCostCalculator.PenaltyCalculator -->
+			<param name="rejectRequestIfMaxWaitOrTravelTimeViolated" value="false" />
+			<!-- Bus stop duration. Must be positive. -->
+			<param name="stopDuration" value="60.0"/>
+			<!-- Stop locations file (transit schedule format, but without lines) for DRT stops. Used only for the stopbased mode -->
+			<param name="transitStopFile" value="null"/>
+			<!-- Limit the operation of vehicles to links (of the 'dvrp_routing' network) with 'allowedModes' containing this 'mode'. For backward compatibility, the value is set to false by default - this means that the vehicles are allowed to operate on all links of the 'dvrp_routing' network. The 'dvrp_routing' is defined by DvrpConfigGroup.networkModes) -->
+			<param name="useModeFilteredSubnetwork" value="true"/>
+			<!-- An XML file specifying the vehicle fleet. The file format according to dvrp_vehicles_v1.dtd -->
+			<param name="vehiclesFile"
+				   value="https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v6.1/input/berlin-v6.1.drt-by-rndLocations-10000vehicles-4seats.xml.gz"/>
+			<!-- Writes out detailed DRT customer stats in each iteration. True by default. -->
+			<param name="writeDetailedCustomerStats" value="true"/>
+			<parameterset type="drtfare">
+				<!-- Basefare per Trip (fare = positive value) -->
+				<param name="basefare" value="0.0"/>
+				<!-- Minimum fare per trip (paid instead of the sum of base, time and distance fare if that sum would be lower than the minimum fare, fee = positive value). -->
+				<param name="minFarePerTrip" value="2.0"/>
+				<!-- Daily subscription fee (fee = positive value) -->
+				<param name="dailySubscriptionFee" value="0.0"/>
+				<!-- drt fare per meter (fee = positive value) -->
+				<param name="distanceFare_m" value="0.00035"/>
+				<!-- drt fare per hour (fee = positive value) -->
+				<param name="timeFare_h" value="0.0"/>
+			</parameterset>
+		</parameterset>
+	</module>
+
+	<module name="dvrp">
+		<!-- Mode of which the network will be used for throwing events and hence calculating travel times. Default is car. -->
+		<param name="mobsimMode" value="car"/>
+		<!-- Set of modes of which the network will be used for DVRP travel time estimation and routing DVRP vehicles. Each specific DVRP mode may use a subnetwork of this network for routing vehicles (e.g. DRT buses travelling only along a specified links or serving a limited area). Default is "car" (i.e. single-element set of modes), i.e. the car network is used. Empty value "" (i.e. empty set of modes) means no network filtering, i.e. the original scenario.network is used -->
+		<param name="networkModes" value="drt"/>
+		<!-- Used for OFFLINE estimation of travel times for VrpOptimizer by means of the exponential moving average. The weighting decrease, alpha, must be in (0,1]. We suggest small values of alpha, e.g. 0.05. The averaging starts from the initial travel time estimates. If not provided, the free-speed TTs is used as the initial estimates -->
+		<param name="travelTimeEstimationAlpha" value="0.05"/>
+		<!-- Used for ONLINE estimation of travel times for VrpOptimizer by combining WithinDayTravelTime and DvrpOfflineTravelTimeEstimator. The beta coefficient is provided in seconds and should be either 0 (no online estimation) or positive (mixed online-offline estimation). For 'beta = 0', only the offline estimate is used: 'onlineTT(t) = offlineTT(t)', where 'offlineTT(t)' in the offline estimate for TT at time 't', For 'beta > 0', estimating future TTs at time 't', uses the currently observed TT to correct the offline estimates is made: where 'currentTT' is the currently observed TT, and 'correction = min(1, max(0, 1 - (time - currentTime) / beta))' The rule is that correction decreases linearly from 1 (when 'time = currentTime') to 0 (when 'time = currentTime + beta' For 'time > currentTime + beta' correction is 0, whereas if 'time < currentTime' it is 1. If beta is sufficiently large, 'beta >> 0', only the currently observed TT is used. -->
+		<param name="travelTimeEstimationBeta" value="0.0"/>
+	</module>
+
+	<module name="swissRailRaptor" >
+		<!-- KN comments: in principle, walk as alternative to drt will not work, since drt is always faster. Need to give the ASC to the router! However, with the reduced drt network we should be able to see differentiation.) -->
+
+		<!-- Possible values: CalcLeastCostModePerStop, RandomSelectOneModePerRoutingRequestAndDirection -->
+		<param name="intermodalAccessEgressModeSelection" value="CalcLeastCostModePerStop" />
+		<param name="useIntermodalAccessEgress" value="true" />
+		<parameterset type="intermodalAccessEgress" >
+			<!-- Radius from the origin / destination coord in which transit stops are searched. Only if less than 2 transit stops are found the search radius is increased step-wise until the maximum search radius set in param radius is reached. -->
+			<param name="initialSearchRadius" value="1500.0" />
+			<!-- If the mode is routed on the network, specify which linkId acts as access link to this stop in the transport modes sub-network. -->
+			<param name="linkIdAttribute" value="null" />
+			<!-- Radius from the origin / destination coord in which transit stops are accessible by this mode. -->
+			<param name="maxRadius" value="100000.0" />
+			<param name="mode" value="walk" />
+			<!-- If less than 2 stops were found in initialSearchRadius take the distance of the closest transit stop and add this extension radius to search again.The search radius will not exceed the maximum search radius set in param radius. -->
+			<param name="searchExtensionRadius" value="1000.0" />
+			<!-- Name of the transit stop attribute used to filter stops that should be included in the set of potential stops for access and egress. The attribute should be of type String. 'null' disables the filter and all stops within the specified radius will be used. -->
+			<param name="stopFilterAttribute" value="null" />
+			<!-- Only stops where the filter attribute has the value specified here will be considered as access or egress stops. -->
+			<param name="stopFilterValue" value="null" />
+		</parameterset>
+		<parameterset type="intermodalAccessEgress" >
+			<!-- If more than 1 transit stop is found in the initial search radius, the raptor stop finder will stop to search
+				 * more distant transit stops.
+				 * Setting setInitialSearchRadius(12000) will allow for crossing the whole Berlkoenig area with drt as
+				 * access/egress mode to pt. This way we are on the safe side and do not exclude any theoretically possible
+				 * drt ride.
+				 * Unfortunately that means that for a route from Alexanderplatz to Friedrichstrasse the pt router basically has
+				 * to route from all transit stops in the city center of Berlin to all transit stops in the city center of Berlin,
+				 * because it has to consider all transit stops in that 12 km radius from Alexanderplatz and Friedrichstrasse,
+				 * respectively. This slows down pt routing enormously.
+				 * To speed up there are two options:
+				 *  - restrict the set of transit stops accessible by drt using a stop filter attribute, e.g. only RE+S+U-Bahn
+				 *  - reduce the initial search radius (and thereby effectively prohibit drt rides longer than that initial
+				 *    search radius for access/egress to pt, because there is always more than 1 transit stop in that radius).
+				 *
+				 * For 2528 agents and no stop filter attribute PlanRouter in iteration 1 took
+				 *  - ca. 1 min at InitialSearchRadius 3 km
+				 *  - but 53 min at InitialSearchRadius 12km
+				 *
+				 * So we have to make use of the speed up options (and exclude theoretically possible but unlikely drt trips).
+				 *  - gleich aug'19  -->
+			<param name="initialSearchRadius" value="3000.0" />
+			<param name="linkIdAttribute" value="null" />
+			<!-- Berlkoenig service area has a maximum diameter of ca. 11km, access trips over 12km don't make sense.
+				 Prohibit them to save computation time.
+				 (RandomAccessEgressModeRaptorStopFinder will try again with walk, the other available access/egress mode)
+				 maybe we should restrict even further, see comment below for InitialSearchRadius. -->
+			<param name="maxRadius" value="12000.0" />
+			<param name="mode" value="drt" />
+			<param name="searchExtensionRadius" value="1000.0" />
+			<!-- take care that this still corresponds to the attribute used for tagging these TransitStops in RunDrtOpenBerlinScenario -->
+			<param name="stopFilterAttribute" value="drtStopFilter" />
+			<param name="stopFilterValue" value="station_S/U/RE/RB_drtServiceArea" />
+		</parameterset>
+	</module>
+</config>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,14 @@
 		</dependency>
 
 		<dependency>
+			<!-- for drt dashboard-->
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>drt-extensions</artifactId>
+			<version>${matsim.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>roadpricing</artifactId>
 			<version>${matsim.version}</version>

--- a/src/main/java/org/matsim/legacy/prepare/drt/DrtVehicleCreator.java
+++ b/src/main/java/org/matsim/legacy/prepare/drt/DrtVehicleCreator.java
@@ -80,44 +80,45 @@ public class DrtVehicleCreator {
 
 	public static void main(String[] args) {
 
-		String networkFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-v5.5-network.xml.gz";
-		String populationFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-v5.5-10pct.plans.xml.gz";
-		String facilitiesFile = "";
-		String drtServiceAreaShapeFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-shp/berlin.shp";
-	    CoordinateTransformation ct = TransformationFactory.getCoordinateTransformation("EPSG:31468", "EPSG:31468");
+		String networkFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v6.1/input/berlin-v6.1-network-with-pt.xml.gz";
+//		String populationFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-v5.5-10pct.plans.xml.gz";
+//		String facilitiesFile = "";
+		String drtServiceAreaShapeFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v6.1/input/shp/Berlin_25832.shp";
+		String scenarioCrs = "EPSG:25832";
+		String shapeCrs = "EPSG:25832";
 
 //		String vehiclesFilePrefix = "berlin-drt-v5.5.spandau_b-drt-by-actLocations-sqrt-";
 		String vehiclesFilePrefix = "berlin-drt-v5.5.drt-by-rndLocations-";
 
 		Set<Integer> numbersOfVehicles = new HashSet<>();
-		numbersOfVehicles.add(20);
-		numbersOfVehicles.add(30);
-		numbersOfVehicles.add(50);
-		numbersOfVehicles.add(80);
-		numbersOfVehicles.add(100);
-		numbersOfVehicles.add(120);
-		numbersOfVehicles.add(150);
-		numbersOfVehicles.add(200);
-		numbersOfVehicles.add(250);
-		numbersOfVehicles.add(300);
-		numbersOfVehicles.add(400);
-		numbersOfVehicles.add(500);
-		numbersOfVehicles.add(600);
-		numbersOfVehicles.add(700);
-		numbersOfVehicles.add(800);
-		numbersOfVehicles.add(900);
-		numbersOfVehicles.add(1000);
-		numbersOfVehicles.add(1200);
-		numbersOfVehicles.add(1500);
-		numbersOfVehicles.add(2000);
-		numbersOfVehicles.add(2500);
-		numbersOfVehicles.add(3000);
-		numbersOfVehicles.add(4000);
-		numbersOfVehicles.add(5000);
+//		numbersOfVehicles.add(20);
+//		numbersOfVehicles.add(30);
+//		numbersOfVehicles.add(50);
+//		numbersOfVehicles.add(80);
+//		numbersOfVehicles.add(100);
+//		numbersOfVehicles.add(120);
+//		numbersOfVehicles.add(150);
+//		numbersOfVehicles.add(200);
+//		numbersOfVehicles.add(250);
+//		numbersOfVehicles.add(300);
+//		numbersOfVehicles.add(400);
+//		numbersOfVehicles.add(500);
+//		numbersOfVehicles.add(600);
+//		numbersOfVehicles.add(700);
+//		numbersOfVehicles.add(800);
+//		numbersOfVehicles.add(900);
+//		numbersOfVehicles.add(1000);
+//		numbersOfVehicles.add(1200);
+//		numbersOfVehicles.add(1500);
+//		numbersOfVehicles.add(2000);
+//		numbersOfVehicles.add(2500);
+//		numbersOfVehicles.add(3000);
+//		numbersOfVehicles.add(4000);
+//		numbersOfVehicles.add(5000);
 		numbersOfVehicles.add(10000);
 		int seats = 4;
 
-		DrtVehicleCreator tvc = new DrtVehicleCreator(networkFile, drtServiceAreaShapeFile, ct);
+		DrtVehicleCreator tvc = new DrtVehicleCreator(networkFile, drtServiceAreaShapeFile, shapeCrs, scenarioCrs);
 //		tvc.setLinkWeightsByActivities(populationFile, facilitiesFile);
 //		tvc.setWeightsToSquareRoot();
 		for (int numberOfVehicles: numbersOfVehicles) {
@@ -126,10 +127,11 @@ public class DrtVehicleCreator {
 		}
 }
 
-	public DrtVehicleCreator(String networkfile, String drtServiceAreaShapeFile, CoordinateTransformation ct) {
-		this.ct = ct;
+	public DrtVehicleCreator(String networkfile, String drtServiceAreaShapeFile, String shapeCrs, String scenarioCrs) {
+		this.ct = TransformationFactory.getCoordinateTransformation(shapeCrs, scenarioCrs);
 
 		Config config = ConfigUtils.createConfig();
+		config.global().setCoordinateSystem(scenarioCrs);
 		config.network().setInputFile(networkfile);
 		this.scenario = ScenarioUtils.loadScenario(config);
 

--- a/src/main/java/org/matsim/legacy/prepare/drt/DrtVehicleCreator.java
+++ b/src/main/java/org/matsim/legacy/prepare/drt/DrtVehicleCreator.java
@@ -81,21 +81,21 @@ public class DrtVehicleCreator {
 	public static void main(String[] args) {
 
 		String networkFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v6.1/input/berlin-v6.1-network-with-pt.xml.gz";
-//		String populationFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v5.5-10pct/input/berlin-v5.5-10pct.plans.xml.gz";
+//		String populationFile = "";
 //		String facilitiesFile = "";
 		String drtServiceAreaShapeFile = "https://svn.vsp.tu-berlin.de/repos/public-svn/matsim/scenarios/countries/de/berlin/berlin-v6.1/input/shp/Berlin_25832.shp";
 		String scenarioCrs = "EPSG:25832";
 		String shapeCrs = "EPSG:25832";
 
-//		String vehiclesFilePrefix = "berlin-drt-v5.5.spandau_b-drt-by-actLocations-sqrt-";
-		String vehiclesFilePrefix = "berlin-drt-v5.5.drt-by-rndLocations-";
+//		String vehiclesFilePrefix = "berlin-v6.1.spandau_b-drt-by-actLocations-sqrt-";
+		String vehiclesFilePrefix = "berlin-v6.1.drt-by-rndLocations-";
 
 		Set<Integer> numbersOfVehicles = new HashSet<>();
 //		numbersOfVehicles.add(20);
 //		numbersOfVehicles.add(30);
 //		numbersOfVehicles.add(50);
 //		numbersOfVehicles.add(80);
-//		numbersOfVehicles.add(100);
+		numbersOfVehicles.add(100);
 //		numbersOfVehicles.add(120);
 //		numbersOfVehicles.add(150);
 //		numbersOfVehicles.add(200);
@@ -115,7 +115,7 @@ public class DrtVehicleCreator {
 //		numbersOfVehicles.add(3000);
 //		numbersOfVehicles.add(4000);
 //		numbersOfVehicles.add(5000);
-		numbersOfVehicles.add(10000);
+//		numbersOfVehicles.add(10000);
 		int seats = 4;
 
 		DrtVehicleCreator tvc = new DrtVehicleCreator(networkFile, drtServiceAreaShapeFile, shapeCrs, scenarioCrs);

--- a/src/main/java/org/matsim/legacy/run/drt/OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier.java
+++ b/src/main/java/org/matsim/legacy/run/drt/OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier.java
@@ -52,7 +52,7 @@ public final class OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier impleme
 		drtModes = Arrays.asList(TransportMode.drt, "drt2", "drt_teleportation");
 
 		modeHierarchy.add( TransportMode.walk ) ;
-		modeHierarchy.add( "bicycle" ); // TransportMode.bike is not registered as main mode, only "bicycle" ;
+		modeHierarchy.add( TransportMode.bike ); // TransportMode.bike is not registered as main mode, only "bicycle" ;
 		modeHierarchy.add( TransportMode.ride ) ;
 		modeHierarchy.add( TransportMode.car ) ;
 		modeHierarchy.add( "car2" ) ;
@@ -61,6 +61,7 @@ public final class OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier impleme
 		}
 		modeHierarchy.add( TransportMode.pt ) ;
 		modeHierarchy.add( "freight" );
+		modeHierarchy.add( "truck" );
 
 		// NOTE: This hierarchical stuff is not so great: is park-n-ride a car trip or a pt trip?  Could weigh it by distance, or by time spent
 		// in respective mode.  Or have combined modes as separate modes.  In any case, can't do it at the leg level, since it does not

--- a/src/main/java/org/matsim/legacy/run/drt/OpenBerlinIntermodalPtDrtRouterModeIdentifier.java
+++ b/src/main/java/org/matsim/legacy/run/drt/OpenBerlinIntermodalPtDrtRouterModeIdentifier.java
@@ -48,7 +48,7 @@ public final class OpenBerlinIntermodalPtDrtRouterModeIdentifier implements Anal
 		drtModes = Arrays.asList(TransportMode.drt, "drt2", "drt_teleportation");
 
 		modeHierarchy.add( TransportMode.walk ) ;
-		modeHierarchy.add( "bicycle" ); // TransportMode.bike is not registered as main mode, only "bicycle" ;
+		modeHierarchy.add( TransportMode.bike );
 		modeHierarchy.add( TransportMode.ride ) ;
 		modeHierarchy.add( TransportMode.car ) ;
 		modeHierarchy.add( "car2" ) ;

--- a/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
@@ -21,6 +21,7 @@
 package org.matsim.run;
 
 import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
+import ch.sbb.matsim.routing.pt.raptor.RaptorIntermodalAccessEgress;
 import com.beust.jcommander.internal.Lists;
 import com.google.common.collect.ImmutableSet;
 import org.apache.logging.log4j.LogManager;
@@ -50,6 +51,7 @@ import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorConfigGroup;
 import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorsConfigGroup;
 import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorsModule;
+import org.matsim.extensions.pt.routing.EnhancedRaptorIntermodalAccessEgress;
 import org.matsim.extensions.pt.routing.ptRoutingModes.PtIntermodalRoutingModesConfigGroup;
 import org.matsim.extensions.pt.routing.ptRoutingModes.PtIntermodalRoutingModesModule;
 import org.matsim.legacy.run.BerlinExperimentalConfigGroup;
@@ -193,6 +195,7 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 			public void install() {
 				bind(AnalysisMainModeIdentifier.class).to(OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier.class);
 				bind(MainModeIdentifier.class).to(OpenBerlinIntermodalPtDrtRouterModeIdentifier.class);
+				bind(RaptorIntermodalAccessEgress.class).to(EnhancedRaptorIntermodalAccessEgress.class);
 
 			}
 		});

--- a/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
@@ -115,15 +115,15 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 		//drt only works with the following sim start time interpretation
 		config.qsim().setSimStarttimeInterpretation(QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime);
 
-		MultiModeDrtConfigGroup multiMideDrtCfg = MultiModeDrtConfigGroup.get(config);
-		DrtConfigs.adjustMultiModeDrtConfig(multiMideDrtCfg, config.scoring(), config.routing());
+		MultiModeDrtConfigGroup multiModeDrtCfg = MultiModeDrtConfigGroup.get(config);
+		DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtCfg, config.scoring(), config.routing());
 
 		Set<String> modes = new HashSet<>();
 
 		ScoringConfigGroup.ModeParams ptParams = config.scoring().getModes().get(TransportMode.pt);
 		IntermodalTripFareCompensatorsConfigGroup compensatorsConfig = ConfigUtils.addOrGetModule(config, IntermodalTripFareCompensatorsConfigGroup.class);
 
-		for (DrtConfigGroup drtCfg : multiMideDrtCfg.getModalElements()) {
+		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
 			modes.add(drtCfg.getMode());
 
 			//copy all scoring params from pt

--- a/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
@@ -138,6 +138,7 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 			//assume that the drt is fully integrated in pt, i.e. fare integration
 			modeParams.setMonetaryDistanceRate(ptParams.getMonetaryDistanceRate());
 			modeParams.setDailyMonetaryConstant(ptParams.getDailyMonetaryConstant());
+			config.scoring().addModeParams(modeParams);
 		}
 
 		//assume that (all) the drt is fully integrated in pt, i.e. fare integration
@@ -227,7 +228,6 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 					}
 				}
 
-				//TODO: check if the new transitSchedule has the 'stopFilter' attribute
 				tagTransitStopsInServiceArea(scenario.getTransitSchedule(),
 					"drtStopFilter", "station_S/U/RE/RB_drtServiceArea",
 					drtServiceAreaShapeFile,

--- a/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
@@ -83,10 +83,6 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 		description = "Path to drt (only) config. Should contain only additional stuff to base config. Otherwise overrides.")
 	private String drtConfig;
 
-	public OpenBerlinDrtScenario(){
-		super();
-	}
-
 	public static void main(String[] args) {
 		MATSimApplication.run(OpenBerlinDrtScenario.class, args);
 	}
@@ -207,8 +203,8 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 	}
 
 	/**
-	 * this code is copied from matsim-berlin v5.x {@code RunDrtOpenBerlinScenario.prepareScenario()} and sub-methods.
-	 * @param scenario
+	 * This code is copied from matsim-berlin v5.x {@code RunDrtOpenBerlinScenario.prepareScenario()} and sub-methods.
+	 * @param scenario network and transit schedule are mutated as side effects.
 	 */
 	private static void prepareNetworkAndTransitScheduleForDrt(Scenario scenario) {
 		BerlinExperimentalConfigGroup berlinCfg = ConfigUtils.addOrGetModule(scenario.getConfig(), BerlinExperimentalConfigGroup.class);
@@ -218,7 +214,7 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 			String drtServiceAreaShapeFile = drtCfg.drtServiceAreaShapeFile;
 			if (drtServiceAreaShapeFile != null && !drtServiceAreaShapeFile.equals("") && !drtServiceAreaShapeFile.equals("null")) {
 
-				if(dvrpConfigGroup.networkModes.contains(drtCfg.getMode())){
+				if (dvrpConfigGroup.networkModes.contains(drtCfg.getMode())){
 					// Michal says restricting drt to a drt network roughly the size of the service area helps to speed up.
 					// This is even more true since drt started to route on a freespeed TT matrix (Nov '20).
 					// A buffer of 10km to the service area Berlin includes the A10 on some useful stretches outside Berlin.
@@ -236,7 +232,7 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario{
 					// Hermannstr., so allow buffer around the shape.
 					// This does not mean that a drt vehicle can pick the passenger up outside the service area,
 					// rather the passenger has to walk the last few meters from the drt drop off to the station.
-					200.0); //
+					200.0);
 			}
 		}
 	}

--- a/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
@@ -1,0 +1,263 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.run;
+
+import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
+import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.ImmutableSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.application.MATSimApplication;
+import org.matsim.contrib.drt.routing.DrtRoute;
+import org.matsim.contrib.drt.routing.DrtRouteFactory;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.DrtConfigs;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.QSimConfigGroup;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.population.routes.RouteFactories;
+import org.matsim.core.router.AnalysisMainModeIdentifier;
+import org.matsim.core.router.MainModeIdentifier;
+import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorConfigGroup;
+import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorsConfigGroup;
+import org.matsim.extensions.pt.fare.intermodalTripFareCompensator.IntermodalTripFareCompensatorsModule;
+import org.matsim.extensions.pt.routing.ptRoutingModes.PtIntermodalRoutingModesConfigGroup;
+import org.matsim.extensions.pt.routing.ptRoutingModes.PtIntermodalRoutingModesModule;
+import org.matsim.legacy.run.BerlinExperimentalConfigGroup;
+import org.matsim.legacy.run.drt.BerlinShpUtils;
+import org.matsim.legacy.run.drt.OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier;
+import org.matsim.legacy.run.drt.OpenBerlinIntermodalPtDrtRouterModeIdentifier;
+import org.matsim.legacy.run.drt.RunDrtOpenBerlinScenario;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import picocli.CommandLine;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Extend the {@link OpenBerlinScenario} by DRT functionality. <br>
+ * By default, a config is loaded where a drt mode is operated in all of Berlin with 10,000 vehicles. <br>
+ * Alternatively, you can provide another drt-only config using the {@code --drt-config} comand line option. <br>
+ * This run script then configures drt to be perceived just like pt and to be fully tariff-integrated into pt. <br>
+ */
+public class OpenBerlinDrtScenario extends OpenBerlinScenario{
+
+	//TODO: write tests
+
+	private static final Logger log = LogManager.getLogger(OpenBerlinDrtScenario.class);
+
+	@CommandLine.Option(names = "--drt-config",
+		defaultValue = "input/v6.1/berlin-v6.1.drt-config.xml",
+		description = "Path to drt (only) config. Should contain only additional stuff to base config. Otherwise overrides.")
+	private String drtConfig;
+
+	public OpenBerlinDrtScenario(){
+		super();
+	}
+
+	public static void main(String[] args) {
+		MATSimApplication.run(OpenBerlinDrtScenario.class, args);
+	}
+
+	@Override
+	protected List<ConfigGroup> getCustomModules() {
+		List<ConfigGroup> customModules = super.getCustomModules();
+		customModules.addAll(Lists.newArrayList(
+			new BerlinExperimentalConfigGroup(),
+			new DvrpConfigGroup(),
+			new MultiModeDrtConfigGroup(),
+			new SwissRailRaptorConfigGroup(),
+			new IntermodalTripFareCompensatorsConfigGroup(),
+			new PtIntermodalRoutingModesConfigGroup()));
+		return customModules;
+	}
+
+	@Override
+	protected Config prepareConfig(Config config) {
+		super.prepareConfig(config);
+
+		ConfigUtils.loadConfig(config, drtConfig);
+
+		//modify output directory and runId
+		config.controller().setOutputDirectory(config.controller().getOutputDirectory() + "-drt");
+		config.controller().setRunId(config.controller().getRunId() + "-drt");
+
+		//drt only works with the following sim start time interpretation
+		config.qsim().setSimStarttimeInterpretation(QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime);
+
+		MultiModeDrtConfigGroup multiMideDrtCfg = MultiModeDrtConfigGroup.get(config);
+		DrtConfigs.adjustMultiModeDrtConfig(multiMideDrtCfg, config.scoring(), config.routing());
+
+		Set<String> modes = new HashSet<>();
+
+		ScoringConfigGroup.ModeParams ptParams = config.scoring().getModes().get(TransportMode.pt);
+		IntermodalTripFareCompensatorsConfigGroup compensatorsConfig = ConfigUtils.addOrGetModule(config, IntermodalTripFareCompensatorsConfigGroup.class);
+
+		for (DrtConfigGroup drtCfg : multiMideDrtCfg.getModalElements()) {
+			modes.add(drtCfg.getMode());
+
+			//copy all scoring params from pt
+			ScoringConfigGroup.ModeParams modeParams = new ScoringConfigGroup.ModeParams(drtCfg.getMode());
+			modeParams.setConstant(ptParams.getConstant());
+			modeParams.setMarginalUtilityOfDistance(ptParams.getMarginalUtilityOfDistance());
+			modeParams.setMarginalUtilityOfTraveling(ptParams.getMarginalUtilityOfTraveling());
+			modeParams.setDailyUtilityConstant(ptParams.getDailyUtilityConstant());
+
+			//assume that the drt is fully integrated in pt, i.e. fare integration
+			modeParams.setMonetaryDistanceRate(ptParams.getMonetaryDistanceRate());
+			modeParams.setDailyMonetaryConstant(ptParams.getDailyMonetaryConstant());
+		}
+
+		//assume that (all) the drt is fully integrated in pt, i.e. fare integration
+		IntermodalTripFareCompensatorConfigGroup drtCompensationCfg = new IntermodalTripFareCompensatorConfigGroup();
+		drtCompensationCfg.setCompensationCondition(IntermodalTripFareCompensatorConfigGroup.CompensationCondition.PtModeUsedAnywhereInTheDay);
+		drtCompensationCfg.setCompensationMoneyPerDay(ptParams.getDailyMonetaryConstant());
+		drtCompensationCfg.setNonPtModes(ImmutableSet
+			.<String>builder()
+			.addAll(modes)
+			.build());
+		compensatorsConfig.addParameterSet(drtCompensationCfg);
+
+		//include drt in mode-choice and add mode params.
+		//by using a Set, it should be assured that they aren't included twice.
+		modes.addAll(Arrays.asList(config.subtourModeChoice().getModes()));
+		config.subtourModeChoice().setModes(modes.toArray(String[]::new));
+
+		//Here (or when extending this class), you can configure the dvrp and the drt config groups.
+		//Of course you can configure on the xml (config) level, alternatively.
+		//for example you can configure prices and compensations, service area etc.,
+		//whether dvrp modes should operate on a mode-specific sub-network or on the entire car-network,
+		//how the time-constraints for the dispatch should be parameterized etc.
+
+		return config;
+	}
+
+	@Override
+	protected void prepareScenario(Scenario scenario) {
+		super.prepareScenario(scenario);
+
+		//if the input plans contain DrtRoutes, this will cause problems later in the DrtRouteFactory
+		//to avoid this, the DrtRouteFactory would have to get set before loading the scenario, just like in Open Berlin v5.x
+		RouteFactories routeFactories = scenario.getPopulation().getFactory().getRouteFactories();
+		routeFactories.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
+
+		//if the drt mode is configured as a dvrp network mode and if it has a service area
+		//the drt mode is added to the links in the service area with a buffer of +2000 meter (per default or otherwise configured in BerlinExperimentalConfigGroup)
+		//and transit stops 200m around the service area are tagged to be be served by the corresponding drt.
+		prepareNetworkAndTransitScheduleForDrt(scenario);
+
+		//Here (or when extending this class), you can mutate the scenario (e.g. population, network, ...)
+	}
+
+	@Override
+	protected void prepareControler(Controler controler) {
+		super.prepareControler(controler);
+
+		// drt + dvrp modules
+		controler.addOverridingModule(new MultiModeDrtModule());
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeDrtConfigGroup.get(controler.getConfig())));
+
+		controler.addOverridingModule(new AbstractModule() {
+
+			@Override
+			public void install() {
+				bind(AnalysisMainModeIdentifier.class).to(OpenBerlinIntermodalPtDrtRouterAnalysisModeIdentifier.class);
+				bind(MainModeIdentifier.class).to(OpenBerlinIntermodalPtDrtRouterModeIdentifier.class);
+
+			}
+		});
+
+		// yyyy there is fareSModule (with S) in config. ?!?!  kai, jul'19
+		controler.addOverridingModule(new IntermodalTripFareCompensatorsModule());
+		controler.addOverridingModule(new PtIntermodalRoutingModesModule());
+	}
+
+	/**
+	 * this code is copied from matsim-berlin v5.x {@code RunDrtOpenBerlinScenario.prepareScenario()} and sub-methods.
+	 * @param scenario
+	 */
+	private static void prepareNetworkAndTransitScheduleForDrt(Scenario scenario) {
+		BerlinExperimentalConfigGroup berlinCfg = ConfigUtils.addOrGetModule(scenario.getConfig(), BerlinExperimentalConfigGroup.class);
+		DvrpConfigGroup dvrpConfigGroup = DvrpConfigGroup.get(scenario.getConfig());
+
+		for (DrtConfigGroup drtCfg : MultiModeDrtConfigGroup.get(scenario.getConfig()).getModalElements()) {
+			String drtServiceAreaShapeFile = drtCfg.drtServiceAreaShapeFile;
+			if (drtServiceAreaShapeFile != null && !drtServiceAreaShapeFile.equals("") && !drtServiceAreaShapeFile.equals("null")) {
+
+				if(dvrpConfigGroup.networkModes.contains(drtCfg.getMode())){
+					// Michal says restricting drt to a drt network roughly the size of the service area helps to speed up.
+					// This is even more true since drt started to route on a freespeed TT matrix (Nov '20).
+					// A buffer of 10km to the service area Berlin includes the A10 on some useful stretches outside Berlin.
+					if (berlinCfg.getTagDrtLinksBufferAroundServiceAreaShp() >= 0.0) {
+						//TODO: inline/move method ?
+						RunDrtOpenBerlinScenario.addDRTmode(scenario, drtCfg.getMode(), drtServiceAreaShapeFile, berlinCfg.getTagDrtLinksBufferAroundServiceAreaShp());
+					}
+				}
+
+				//TODO: check if the new transitSchedule has the 'stopFilter' attribute
+				tagTransitStopsInServiceArea(scenario.getTransitSchedule(),
+					"drtStopFilter", "station_S/U/RE/RB_drtServiceArea",
+					drtServiceAreaShapeFile,
+					"stopFilter", "station_S/U/RE/RB",
+					// some S+U stations are located slightly outside the shp File, e.g. U7 Neukoelln, U8
+					// Hermannstr., so allow buffer around the shape.
+					// This does not mean that a drt vehicle can pick the passenger up outside the service area,
+					// rather the passenger has to walk the last few meters from the drt drop off to the station.
+					200.0); //
+			}
+		}
+	}
+
+	private static void tagTransitStopsInServiceArea(TransitSchedule transitSchedule,
+													 String newAttributeName, String newAttributeValue,
+													 String drtServiceAreaShapeFile,
+													 String oldFilterAttribute, String oldFilterValue,
+													 double bufferAroundServiceArea) {
+		log.info("Tagging pt stops marked for intermodal access/egress in the service area.");
+		BerlinShpUtils shpUtils = new BerlinShpUtils(drtServiceAreaShapeFile);
+		for (TransitStopFacility stop : transitSchedule.getFacilities().values()) {
+			if (stop.getAttributes().getAttribute(oldFilterAttribute) != null) {
+				if (stop.getAttributes().getAttribute(oldFilterAttribute).equals(oldFilterValue)) {
+					if (shpUtils.isCoordInDrtServiceAreaWithBuffer(stop.getCoord(), bufferAroundServiceArea)) {
+						stop.getAttributes().putAttribute(newAttributeName, newAttributeValue);
+					}
+				}
+			}
+		}
+	}
+
+
+}


### PR DESCRIPTION
1. Add `OpenBerlinDrtScenario`, which is a run class for drt loading
2. an additional `berlin-v6.1.drt-config.xml` which only contains drt-specific and no duplicative stuff compared to base config
3. all necessary input is provided via svn and all necessary base config adjustments are done in the `OpenBerlinDrtScenario` code 

By default, a drt service in all of Berlin with 10,000 vehicles is simulated and configured to be perceived just like pt and to be fully tariff-integrated (@vsp-gleich maybe you can double-check??).

Currently, the following exception is thrown after iteration 0. @vsp-gleich can you help me with setting the marginal utility of travel time in the RaptorParameters?? Couldn't see how it's done by looking into the v5.x code....

```
java.lang.NullPointerException: Marginal utility of travel time is missing for mode: drt
	at ch.sbb.matsim.routing.pt.raptor.RaptorParameters.getMarginalUtilityOfTravelTime_utl_s(RaptorParameters.java:116) ~[matsim-16.0-PR3172.jar:?]
	at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorIntermodalAccessEgress.calcIntermodalAccessEgress(DefaultRaptorIntermodalAccessEgress.java:50) ~[matsim-16.0-PR3172.jar:?]
	at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.addInitialStopsForParamSet(DefaultRaptorStopFinder.java:258) ~[matsim-16.0-PR3172.jar:?]
	at ch.sbb.matsim.routing.pt.raptor.DefaultRaptorStopFinder.findIntermodalStops(DefaultRaptorStopFinder.java:146) ~[matsim-16.0-PR3172.jar:?]
```

There are a few ToDos, most importantly to implement tests ... 

