### PR TITLE
add comment for source of calibration target modal split

### DIFF
--- a/src/main/python/calibrate.py
+++ b/src/main/python/calibrate.py
@@ -14,7 +14,7 @@ initial = {
     "ride": -1.4
 }
 
-# Original modal split
+# modal split according to SrV 2018 (shared-svn/projects/matsim-berlin/data/SrV)
 target = {
     "walk": 0.296769,
     "bike": 0.177878,


### PR DESCRIPTION
@rakow I was searching with Kai which calibration modal split data we are using. We should comment next to the values where that data is from. I found SrV _2017_ (sic!) in the calibration log and added a comment here (SrV _2018_). Is this correct?