### PR TITLE
dev/v7: update matsim version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           architecture: x64
-          distribution: adopt
+          distribution: temurin
           cache: maven
 
       - name: Package
@@ -32,9 +32,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           architecture: x64
-          distribution: adopt
+          distribution: temurin
           cache: maven
 
       - name: Package
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [21]
+        java: [25]
 
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           architecture: x64
-          distribution: adopt
+          distribution: temurin
           cache: maven
 
       - name: Test
@@ -80,9 +80,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           architecture: x64
-          distribution: adopt
+          distribution: temurin
           cache: maven
 
       - name: Package

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,9 +9,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 21
+          java-version: 25
           architecture: x64
-          distribution: adopt
+          distribution: temurin
 
       - name: Publish package
         run: mvn --batch-mode deploy

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,6 @@
 jdk:
-  - openjdk21
+  - openjdk25
 before_install:
-  - sdk install java 21.0.3-tem
-  - sdk use java 21.0.3-tem
+  - sdk install java 25.0.3-tem
+  - sdk use java 25.0.3-tem
   - sdk install maven

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<artifactId>matsim-all</artifactId>
 
 		<!-- PR-labelled release -->
-		<version>2026.0-PR3947</version>
+		<version>2027.0-PR4869</version>
 
 		<!-- snapshot == not recommended: rather use PR-labelled release!-->
 <!--		<version>2026.0-SNAPSHOT</version>-->
@@ -27,7 +27,7 @@
 
 		<main.class>org.matsim.run.OpenBerlinScenarioWrapper</main.class>
 
-		<maven.compiler.release>21</maven.compiler.release>
+		<maven.compiler.release>25</maven.compiler.release>
 	</properties>
 
 	<dependencies>
@@ -249,13 +249,13 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.3.0</version>
+			<version>5.5.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>de.topobyte</groupId>
 			<artifactId>osm4j-pbf</artifactId>
-			<version>1.3.0</version>
+			<version>1.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>de.topobyte</groupId>
@@ -276,12 +276,12 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-statistics-distribution</artifactId>
-			<version>1.0</version>
+			<version>1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-rng-simple</artifactId>
-			<version>1.5</version>
+			<version>1.7</version>
 		</dependency>
 
 
@@ -339,7 +339,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.12</version>
+				<version>0.8.14</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
 				</executions>
 			</plugin>
 
-			<plugin>
+			<!-- <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>3.4.0</version>
@@ -455,7 +455,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 
 		</plugins>
 	</build>

--- a/src/main/java/org/matsim/analysis/DTVAnalysis.java
+++ b/src/main/java/org/matsim/analysis/DTVAnalysis.java
@@ -58,7 +58,7 @@ public class DTVAnalysis implements MATSimAppCommand {
 		Table dtv;
 		try (BufferedReader reader = IOUtils.getBufferedReader(dtvPath)) {
 			dtv = Table.read().csv(CsvReadOptions.builder(reader)
-				.columnTypesPartial(Map.of("from_link", ColumnType.TEXT, "to_link", ColumnType.TEXT))
+				.columnTypesPartial(Map.of("from_link", ColumnType.STRING, "to_link", ColumnType.STRING))
 				.build());
 		}
 
@@ -108,7 +108,7 @@ public class DTVAnalysis implements MATSimAppCommand {
 	private Table createSimDtvTable(Table dtv, Network network, VolumesAnalyzer volume) {
 
 		dtv.addColumns(
-			TextColumn.create("link_id"),
+			StringColumn.create("link_id"),
 			StringColumn.create("road_type"),
 			DoubleColumn.create("simulated_traffic_volume"),
 			DoubleColumn.create("diff"),
@@ -135,8 +135,8 @@ public class DTVAnalysis implements MATSimAppCommand {
 				vol += sum(volume.getVolumesForLink(linkId)) * sample.getUpscaleFactor();
 			}
 
-			row.setText("link_id", linkId.toString());
-			row.setText("road_type", NetworkUtils.getHighwayType(network.getLinks().get(linkId)));
+			row.setString("link_id", linkId.toString());
+			row.setString("road_type", NetworkUtils.getHighwayType(network.getLinks().get(linkId)));
 			row.setDouble("diff", vol - row.getInt("vol"));
 			row.setDouble("simulated_traffic_volume", vol);
 			row.setDouble("abs_error", Math.abs(vol - row.getInt("vol")));

--- a/src/main/java/org/matsim/dashboard/DTVComparisonDashboard.java
+++ b/src/main/java/org/matsim/dashboard/DTVComparisonDashboard.java
@@ -5,6 +5,7 @@ import org.matsim.application.prepare.network.CreateGeoJsonNetwork;
 import org.matsim.simwrapper.Dashboard;
 import org.matsim.simwrapper.Header;
 import org.matsim.simwrapper.Layout;
+import org.matsim.simwrapper.SimWrapperConfigGroup;
 import org.matsim.simwrapper.viz.ColorScheme;
 import org.matsim.simwrapper.viz.MapPlot;
 import org.matsim.simwrapper.viz.Plotly;
@@ -30,7 +31,7 @@ public class DTVComparisonDashboard implements Dashboard {
 	}
 
 	@Override
-	public void configure(Header header, Layout layout) {
+	public void configure(Header header, Layout layout, SimWrapperConfigGroup configGroup) {
 
 		header.title = "DTV";
 		header.description = "Analysis of dtv data provided by 'FIS-Broker' (Open geo-data portal by Berlin). Error metrics: under: < 0.75; over: > 1.25";

--- a/src/main/java/org/matsim/legacy/prepare/accidents/WriteBVWPAccidentRoadTypesIntoLinkAttributes.java
+++ b/src/main/java/org/matsim/legacy/prepare/accidents/WriteBVWPAccidentRoadTypesIntoLinkAttributes.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.accidents.AccidentsConfigGroup;
-import org.matsim.contrib.accidents.runExample.AccidentsNetworkModification;
+import org.matsim.contrib.accidents.AccidentsNetworkModification;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.NetworkUtils;
@@ -44,7 +44,7 @@ public class WriteBVWPAccidentRoadTypesIntoLinkAttributes {
 	Scenario scenario = RunBerlinScenario.prepareScenario(config);
 
 	AccidentsNetworkModification accidentsNetworkModification = new AccidentsNetworkModification(scenario);
-	NetworkUtils.writeNetwork(accidentsNetworkModification.setLinkAttributsBasedOnOSMFile(
+	NetworkUtils.writeNetwork(accidentsNetworkModification.setLinkAttributesBasedOnOSMFile(
 			landOSMInputShapeFile,
 			"EPSG:31468",
 			readColumn(0,tunnelLinkCSVInputFile,";"),

--- a/src/main/java/org/matsim/legacy/prepare/bicycle/NetworkFileModifier.java
+++ b/src/main/java/org/matsim/legacy/prepare/bicycle/NetworkFileModifier.java
@@ -38,7 +38,7 @@ public class NetworkFileModifier {
         // Add bicycle infrastructure speed factor for all links
         scenario.getNetwork().getLinks().values().parallelStream()
                 .filter(link -> link.getAllowedModes().contains(BICYCLE))
-                .forEach(link -> link.getAttributes().putAttribute(BicycleUtils.BICYCLE_INFRASTRUCTURE_SPEED_FACTOR, 1.0));
+                .forEach(link -> BicycleUtils.setBicycleInfrastructureFactor(link, 1.0));
 
         NetworkWriter networkWriter = new NetworkWriter(scenario.getNetwork());
         networkWriter.write(outputNetworkFile);

--- a/src/main/java/org/matsim/legacy/prepare/population/CreateFreightAgents.java
+++ b/src/main/java/org/matsim/legacy/prepare/population/CreateFreightAgents.java
@@ -43,6 +43,7 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.api.core.v01.population.PopulationWriter;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.gis.ShapeFileReader;
@@ -190,7 +191,7 @@ public class CreateFreightAgents {
 			pers.addPlan(plan) ;
 			population.addPerson(pers) ;
 
-			scenario.getPopulation().getPersons().get(pers.getId()).getAttributes().putAttribute(scenario.getConfig().plans().getSubpopulationAttributeName(), "freight");
+			PopulationUtils.putSubpopulation(scenario.getPopulation().getPersons().get(pers.getId()), "freight");
 
 			personCounter++;
 		}
@@ -224,7 +225,7 @@ public class CreateFreightAgents {
 			pers.addPlan(plan) ;
 			population.addPerson(pers) ;
 
-			scenario.getPopulation().getPersons().get(pers.getId()).getAttributes().putAttribute(scenario.getConfig().plans().getSubpopulationAttributeName(), "freight");
+			PopulationUtils.putSubpopulation(scenario.getPopulation().getPersons().get(pers.getId()), "freight");
 
 			personCounter++;
 		}

--- a/src/main/java/org/matsim/legacy/prepare/population/MergePlans.java
+++ b/src/main/java/org/matsim/legacy/prepare/population/MergePlans.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.io.PopulationWriter;
 import org.matsim.core.scenario.ScenarioUtils;
 
@@ -56,11 +57,11 @@ public class MergePlans {
 
 		for (Person person: scenario1.getPopulation().getPersons().values()) {
 			population.addPerson(person);
-			population.getPersons().get(person.getId()).getAttributes().putAttribute(scenario3.getConfig().plans().getSubpopulationAttributeName(), "person");
+			PopulationUtils.putSubpopulation(population.getPersons().get(person.getId()), "person");
 		}
 		for (Person person : scenario2.getPopulation().getPersons().values()) {
 			population.addPerson(person);
-			population.getPersons().get(person.getId()).getAttributes().putAttribute(scenario3.getConfig().plans().getSubpopulationAttributeName(), "freight");
+			PopulationUtils.putSubpopulation(population.getPersons().get(person.getId()), "person");
 		}
 
 		PopulationWriter writer = new PopulationWriter(population);

--- a/src/main/java/org/matsim/legacy/run/dynamicShutdown/DynamicShutdownControlerListenerImpl.java
+++ b/src/main/java/org/matsim/legacy/run/dynamicShutdown/DynamicShutdownControlerListenerImpl.java
@@ -3,7 +3,7 @@ package org.matsim.legacy.run.dynamicShutdown;
 import jakarta.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.matsim.analysis.ModeStatsControlerListener;
+//import org.matsim.analysis.ModeStatsControllerListener;
 import org.matsim.analysis.ScoreStats;
 import org.matsim.analysis.ScoreStatsControlerListener.ScoreItem;
 import org.matsim.api.core.v01.Scenario;
@@ -50,7 +50,7 @@ public class DynamicShutdownControlerListenerImpl implements IterationStartsList
     private final ScoreStats scoreStats;
     private final ScoringConfigGroup scoreConfig;
     private final ReplanningConfigGroup strategyConfigGroup;
-    private final ModeStatsControlerListener modeStatsControlerListener;
+//    private final ModeStatsControllerListener modeStatsControlerListener;
     private final ModeChoiceCoverageControlerListener modeChoiceCoverageControlerListener;
     private final Scenario scenario;
     private final StrategyManager strategyManager;
@@ -78,7 +78,7 @@ public class DynamicShutdownControlerListenerImpl implements IterationStartsList
 
     @Inject
     DynamicShutdownControlerListenerImpl(ControllerConfigGroup controlerConfigGroup, ScoreStats scoreStats,
-                                         ModeStatsControlerListener modeStatsControlerListener, StrategyManager strategyManager,
+                                         /*ModeStatsControllerListener modeStatsControlerListener,*/ StrategyManager strategyManager,
                                          ReplanningConfigGroup strategyConfigGroup, Scenario scenario, OutputDirectoryHierarchy controlerIO,
                                         ScoringConfigGroup scoreConfig,
                                          ModeChoiceCoverageControlerListener modeChoiceCoverageControlerListener) {
@@ -88,7 +88,7 @@ public class DynamicShutdownControlerListenerImpl implements IterationStartsList
         this.strategyManager = strategyManager;
         this.strategyConfigGroup = strategyConfigGroup;
         this.controlerConfigGroup = controlerConfigGroup ;
-        this.modeStatsControlerListener = modeStatsControlerListener ;
+//        this.modeStatsControlerListener = modeStatsControlerListener ;
         this.outputFileName = controlerIO.getOutputFilename("dynShutdown_");
         this.modeChoiceCoverageControlerListener = modeChoiceCoverageControlerListener;
 

--- a/src/main/java/org/matsim/legacy/run/dynamicShutdown/ModeChoiceCoverageControlerListener.java
+++ b/src/main/java/org/matsim/legacy/run/dynamicShutdown/ModeChoiceCoverageControlerListener.java
@@ -39,7 +39,7 @@ import java.util.Map.Entry;
 public class ModeChoiceCoverageControlerListener implements StartupListener, IterationEndsListener,
         ShutdownListener {
 
-    private final static Logger log = LogManager.getLogger(org.matsim.analysis.ModeStatsControlerListener.class);
+    private final static Logger log = LogManager.getLogger(ModeChoiceCoverageControlerListener.class);
 
 
     private final Map<Integer, BufferedWriter> modeOutMap = new HashMap<>();

--- a/src/main/java/org/matsim/legacy/run/ptdisturbances/RunPtDisturbancesBerlin.java
+++ b/src/main/java/org/matsim/legacy/run/ptdisturbances/RunPtDisturbancesBerlin.java
@@ -435,14 +435,6 @@ public final class RunPtDisturbancesBerlin {
 		}
 
 		@Override
-		public void onPrepareSim() {
-		}
-
-		@Override
-		public void afterSim() {
-		}
-
-		@Override
 		public void setInternalInterface(InternalInterface internalInterface) {
 			this.internalInterface = internalInterface;
 		}
@@ -451,7 +443,7 @@ public final class RunPtDisturbancesBerlin {
 
 	static void replanPtPassengers(double now, final Id<TransitLine> disturbedLineId, Provider<TripRouter> tripRouterProvider, Scenario scenario, InternalInterface internalInterface) {
 
-		final QSim qsim = internalInterface.getMobsim() ;
+		final QSim qsim = (QSim) internalInterface.getMobsim();
 
 		// force new transit router:
 		final TripRouter tripRouter = tripRouterProvider.get();

--- a/src/main/java/org/matsim/prepare/RunOpenBerlinCalibration.java
+++ b/src/main/java/org/matsim/prepare/RunOpenBerlinCalibration.java
@@ -13,7 +13,7 @@ import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.MATSimApplication;
 import org.matsim.application.options.SampleOptions;
 import org.matsim.application.prepare.CreateLandUseShp;
-import org.matsim.application.prepare.freight.tripExtraction.ExtractRelevantFreightTrips;
+import org.matsim.application.prepare.longDistanceFreightGER.tripExtraction.ExtractRelevantFreightTrips;
 import org.matsim.application.prepare.network.CleanNetwork;
 import org.matsim.application.prepare.network.CreateNetworkFromSumo;
 import org.matsim.application.prepare.network.params.ApplyNetworkParams;
@@ -127,7 +127,7 @@ public class RunOpenBerlinCalibration extends MATSimApplication {
 	private Integer planIndex;
 
 	public RunOpenBerlinCalibration() {
-		super("input/v6.4/berlin-v6.4.config.xml");
+		super(ConfigUtils.loadConfig("input/v6.4/berlin-v6.4.config.xml"));
 	}
 
 	/**
@@ -212,7 +212,7 @@ public class RunOpenBerlinCalibration extends MATSimApplication {
 			config.transit().setUseTransit(false);
 
 			// Disable dashboards, for all car runs, these take too many resources
-			sw.setDefaultDashboards(SimWrapperConfigGroup.Mode.disabled);
+			sw.setDefaultDashboards(SimWrapperConfigGroup.DefaultDashboardsMode.disabled);
 
 			// Only car and ride will be network modes, ride is not simulated on the network though
 			config.routing().setNetworkModes(List.of(TransportMode.car, TransportMode.ride));

--- a/src/main/java/org/matsim/prepare/choices/ComputePlanChoices.java
+++ b/src/main/java/org/matsim/prepare/choices/ComputePlanChoices.java
@@ -116,7 +116,7 @@ public class ComputePlanChoices implements MATSimAppCommand, PersonAlgorithm {
 		config.controller().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
 
 		SimWrapperConfigGroup sw = ConfigUtils.addOrGetModule(config, SimWrapperConfigGroup.class);
-		sw.setDefaultDashboards(SimWrapperConfigGroup.Mode.disabled);
+		sw.setDefaultDashboards(SimWrapperConfigGroup.DefaultDashboardsMode.disabled);
 
 		if (timeUtil) {
 			// All utilities except travel time become zero

--- a/src/main/java/org/matsim/prepare/choices/ComputeTripChoices.java
+++ b/src/main/java/org/matsim/prepare/choices/ComputeTripChoices.java
@@ -84,7 +84,7 @@ public class ComputeTripChoices implements MATSimAppCommand {
 		config.controller().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
 
 		SimWrapperConfigGroup sw = ConfigUtils.addOrGetModule(config, SimWrapperConfigGroup.class);
-		sw.setDefaultDashboards(SimWrapperConfigGroup.Mode.disabled);
+		sw.setDefaultDashboards(SimWrapperConfigGroup.DefaultDashboardsMode.disabled);
 
 		Controler controler = this.scenario.createControler();
 

--- a/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinDrtScenario.java
@@ -192,18 +192,19 @@ public class OpenBerlinDrtScenario extends OpenBerlinScenario {
 		new MultimodalNetworkCleaner(scenario.getNetwork()).run(modes);
 	}
 
-	@Override
-	protected List<ConfigGroup> getCustomModules() {
-		List<ConfigGroup> customModules = super.getCustomModules();
-		customModules.addAll(Lists.newArrayList(
-			new BerlinExperimentalConfigGroup(),
-			new DvrpConfigGroup(),
-			new MultiModeDrtConfigGroup(),
-			new SwissRailRaptorConfigGroup(),
-			new IntermodalTripFareCompensatorsConfigGroup(),
-			new PtIntermodalRoutingModesConfigGroup()));
-		return customModules;
-	}
+	// this no longer exists. Not sure how to fix this here, probably in prepareConfig?? //DR20260616
+//	@Override
+//	protected List<ConfigGroup> getCustomModules() {
+//		List<ConfigGroup> customModules = super.getCustomModules();
+//		customModules.addAll(Lists.newArrayList(
+//			new BerlinExperimentalConfigGroup(),
+//			new DvrpConfigGroup(),
+//			new MultiModeDrtConfigGroup(),
+//			new SwissRailRaptorConfigGroup(),
+//			new IntermodalTripFareCompensatorsConfigGroup(),
+//			new PtIntermodalRoutingModesConfigGroup()));
+//		return customModules;
+//	}
 
 	@Override
 	protected Config prepareConfig(Config config) {

--- a/src/main/java/org/matsim/run/OpenBerlinScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinScenario.java
@@ -10,10 +10,7 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.application.MATSimApplication;
-import org.matsim.contrib.bicycle.BicycleConfigGroup;
-import org.matsim.contrib.bicycle.BicycleLinkSpeedCalculator;
-import org.matsim.contrib.bicycle.BicycleLinkSpeedCalculatorDefaultImpl;
-import org.matsim.contrib.bicycle.BicycleTravelTime;
+import org.matsim.contrib.bicycle.*;
 import org.matsim.contrib.emissions.HbefaRoadTypeMapping;
 import org.matsim.contrib.emissions.OsmHbefaMapping;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
@@ -187,6 +184,7 @@ public class OpenBerlinScenario extends MATSimApplication {
 				addTravelDisutilityFactoryBinding("freight").to(Key.get(TravelDisutilityFactory.class, Names.named(TransportMode.truck)));
 
 				bind(BicycleLinkSpeedCalculator.class).to(BicycleLinkSpeedCalculatorDefaultImpl.class);
+				bind(BicycleParams.class).to(BicycleParamsDefaultImpl.class);
 
 				// Bike should use free speed travel time
 				addTravelTimeBinding(TransportMode.bike).to(BicycleTravelTime.class);

--- a/src/main/java/org/matsim/run/OpenBerlinScenario.java
+++ b/src/main/java/org/matsim/run/OpenBerlinScenario.java
@@ -1,7 +1,8 @@
 package org.matsim.run;
 
-import java.util.List;
-
+import com.google.inject.Key;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import org.matsim.analysis.QsimTimingModule;
 import org.matsim.analysis.personMoney.PersonMoneyEventsAnalysisModule;
 import org.matsim.api.core.v01.Scenario;
@@ -25,16 +26,16 @@ import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelTime;
+import org.matsim.dashboard.BerlinDashboardProvider;
 import org.matsim.run.scoring.BerlinScoringModule;
 import org.matsim.run.scoring.experimental.AdvancedScoringConfigGroup;
 import org.matsim.run.scoring.experimental.AdvancedScoringModule;
+import org.matsim.simwrapper.DashboardProvider;
 import org.matsim.simwrapper.SimWrapperConfigGroup;
 import org.matsim.simwrapper.SimWrapperModule;
-
-import com.google.inject.Key;
-import com.google.inject.name.Names;
-
 import picocli.CommandLine;
+
+import java.util.List;
 
 @CommandLine.Command(header = ":: Open Berlin Scenario ::", version = OpenBerlinScenario.VERSION, mixinStandardHelpOptions = true, showDefaultValues = true)
 public class OpenBerlinScenario extends MATSimApplication {
@@ -145,6 +146,14 @@ public class OpenBerlinScenario extends MATSimApplication {
 	protected void prepareControler(Controler controler) {
 
 		controler.addOverridingModule(new SimWrapperModule());
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				BerlinDashboardProvider dashboardProvider = new BerlinDashboardProvider();
+				Multibinder.newSetBinder( binder(), DashboardProvider.class ).addBinding().toInstance( dashboardProvider );
+			}
+		});
+
 		controler.addOverridingModule(new TravelTimeBinding());
 		controler.addOverridingModule(new QsimTimingModule());
 

--- a/src/main/java/org/matsim/run/scoring/BerlinScoringFunctionFactory.java
+++ b/src/main/java/org/matsim/run/scoring/BerlinScoringFunctionFactory.java
@@ -41,7 +41,7 @@ public final class BerlinScoringFunctionFactory implements ScoringFunctionFactor
 
 		SumScoringFunction sumScoringFunction = new SumScoringFunction();
 		sumScoringFunction.addScoringFunction(new CharyparNagelActivityScoring(parameters));
-		sumScoringFunction.addScoringFunction(new CharyparNagelLegScoring(parameters, this.network, config.transit().getTransitModes()));
+		sumScoringFunction.addScoringFunction(new CharyparNagelLegScoring(parameters, config.transit().getTransitModes()));
 		sumScoringFunction.addScoringFunction(new PseudoRandomTripScoring(person.getId(), mmi, pseudoRNG));
 		sumScoringFunction.addScoringFunction(new TransitTripScoring(parameters, ptRouteToMode));
 		sumScoringFunction.addScoringFunction(new CharyparNagelMoneyScoring(parameters));

--- a/src/main/resources/META-INF/services/org.matsim.simwrapper.DashboardProvider
+++ b/src/main/resources/META-INF/services/org.matsim.simwrapper.DashboardProvider
@@ -1,1 +1,0 @@
-org.matsim.dashboard.BerlinDashboardProvider


### PR DESCRIPTION
Running 1pct with v7.1.1 (left) and matsim-berlin-7.1-SNAPSHOT-v7.1.1-5-gd1da061.jar (right) leads to a comparable modeshare and scorestats. 

Stopwatch shows a strong decrease of computationtime. Since both runs were started on different compute-nodes, this is not really comparable.

Overall, results are ok and we can merge.

<img width="2116" height="644" alt="grafik" src="https://github.com/user-attachments/assets/8f77f6b8-7a29-4564-941e-a0404bbf8911" />

<img width="2102" height="626" alt="grafik" src="https://github.com/user-attachments/assets/499daa5f-d8a6-4cb4-92d0-4c36668e193e" />

<img width="2324" height="789" alt="grafik" src="https://github.com/user-attachments/assets/148f6709-79f9-4291-93af-c2c6f0627f27" />
